### PR TITLE
List out tomcat log files to prevent self-rotation

### DIFF
--- a/templates/logrotate_tomcat.j2
+++ b/templates/logrotate_tomcat.j2
@@ -1,6 +1,10 @@
-/var/log/tomcat/catalina.out 
-/var/log/tomcat7/localhost_access_log.txt 
-/var/log/tomcat/*.log{
+/var/log/tomcat/localhost_access_log.txt
+/var/log/tomcat/catalina.out
+/var/log/tomcat/catalina.log
+/var/log/tomcat/localhost.log
+/var/log/tomcat/manager.log
+/var/log/tomcat/host-manager.log
+{
     copytruncate
     daily
     rotate 90
@@ -8,4 +12,3 @@
     missingok
     create 0644 tomcat tomcat
 }
-


### PR DESCRIPTION
Logrotate.d was rotating already rotated files resulting in extreme duplication of logs. As per the documentation from logrotated

> Please use wildcards with caution. If you specify *, logrotate will rotate all files, including previously rotated ones. A way around this is to use the olddir directive or a more exact wildcard (such as *.log).

This is fixed by explicitly listing out log files.

This has been tested on a dspace6 test instance. 