### PR TITLE
Template out tomcat.conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 # Global Tomcat vars
 dspace_tomcats_base: /var/lib/tomcats/
-dspace_java_home: /usr/lib/jvm/jre
+dspace_tomcat_java_home: /usr/lib/jvm/jre
 dspace_catalina_home: /usr/share/tomcat
 dspace_catalina_tmpdir: /var/cache/tomcat/temp
 dspace_catalina_opts: "-Xmx512m -Xms512m"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,14 @@
 ---
 # defaults file for OULibraries.dspace6
 
+# Global Tomcat vars
+tomcats_base: /var/lib/tomcats/
+tomcat_java_home: /usr/lib/jvm/jre
+tomcat_catalina_home: /usr/share/tomcat
+tomcat_catalina_tmpdir: /var/cache/tomcat/temp
+tomcat_catalina_opts: "-Xmx512m -Xms512m"
+tomcat_security_manager: "false"
+
 # Location for  DSpace src, build, and other files
 dspace_install_dir: /srv/dspace
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,9 +4,9 @@
 # Global Tomcat vars
 dspace_tomcats_base: /var/lib/tomcats/
 dspace_tomcat_java_home: /usr/lib/jvm/jre
-dspace_catalina_home: /usr/share/tomcat
-dspace_catalina_tmpdir: /var/cache/tomcat/temp
-dspace_catalina_opts: "-Xmx512m -Xms512m"
+dspace_tomcat_catalina_home: /usr/share/tomcat
+dspace_tomcat_catalina_tmpdir: /var/cache/tomcat/temp
+dspace_tomcat_catalina_opts: "-Xmx512m -Xms512m"
 dspace_tomcat_security_manager: "false"
 
 # Location for  DSpace src, build, and other files

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,12 +2,12 @@
 # defaults file for OULibraries.dspace6
 
 # Global Tomcat vars
-tomcats_base: /var/lib/tomcats/
-tomcat_java_home: /usr/lib/jvm/jre
-tomcat_catalina_home: /usr/share/tomcat
-tomcat_catalina_tmpdir: /var/cache/tomcat/temp
-tomcat_catalina_opts: "-Xmx512m -Xms512m"
-tomcat_security_manager: "false"
+dspace_tomcats_base: /var/lib/tomcats/
+dspace_java_home: /usr/lib/jvm/jre
+dspace_catalina_home: /usr/share/tomcat
+dspace_catalina_tmpdir: /var/cache/tomcat/temp
+dspace_catalina_opts: "-Xmx512m -Xms512m"
+dspace_tomcat_security_manager: "false"
 
 # Location for  DSpace src, build, and other files
 dspace_install_dir: /srv/dspace

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for OULibraries.dspace6
 
 # Global Tomcat vars
-dspace_tomcats_base: /var/lib/tomcats/
+dspace_tomcats_base: /var/lib/tomcat/
 dspace_tomcat_java_home: /usr/lib/jvm/jre
 dspace_tomcat_catalina_home: /usr/share/tomcat
 dspace_tomcat_catalina_tmpdir: /var/cache/tomcat/temp

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -33,12 +33,13 @@
   template:
     src: jmxremote.access.j2  
     dest: "{{ dspace_install_dir }}/etc/jmxremote.access"
+  when: jmx_user is defined
         
 - name: Install JMX password file
   template:
     src: jmxremote.access.j2  
     dest: "{{ dspace_install_dir }}/etc/jmxremote.password"
-
+  when: jmx_user is defined
 # Do we also need a JMX Keystore?
 
 - name: Install build config

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -18,30 +18,6 @@
   command: >
           semanage fcontext -a -t tomcat_var_lib_t  "{{ dspace_install_dir }}(/.*)?"
 
-# These can end up with a value that won't work for the tomcat service because
-# we build DSpace as tomcat.  
-- name: Set SELinux tomcat hsperfdata
-  command: >
-          semanage fcontext -a -t tomcat_tmp_t  "/tmp/hsperfdata_tomcat(/.*)?"
-
-- name: Set SELinux booleans
-  seboolean:
-    name: tomcat_can_network_connect_db
-    state: yes
-
-- name: Install JMX user file
-  template:
-    src: jmxremote.access.j2  
-    dest: "{{ dspace_install_dir }}/etc/jmxremote.access"
-  when: jmx_user is defined
-        
-- name: Install JMX password file
-  template:
-    src: jmxremote.password.j2  
-    dest: "{{ dspace_install_dir }}/etc/jmxremote.password"
-  when: jmx_user is defined
-# Do we also need a JMX Keystore?
-
 - name: Install build config
   template:
     src: conf.sh.j2
@@ -61,11 +37,3 @@
       dest: fix_perms.sh
     - src: git_pull.sh.j2
       dest: git_pull.sh
-
-- name: Install tomcat crontab for dspace 
-  template:
-    dest: /var/spool/cron/tomcat
-    src: tomcat-cron.j2
-    mode: 0600
-    owner: tomcat
-    group: tomcat

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -37,7 +37,7 @@
         
 - name: Install JMX password file
   template:
-    src: jmxremote.access.j2  
+    src: jmxremote.password.j2  
     dest: "{{ dspace_install_dir }}/etc/jmxremote.password"
   when: jmx_user is defined
 # Do we also need a JMX Keystore?

--- a/tasks/tomcat.yml
+++ b/tasks/tomcat.yml
@@ -72,14 +72,13 @@
   template:
     src: jmxremote.access.j2  
     dest: "{{ dspace_install_dir }}/etc/jmxremote.access"
-  when: jmx_user is defined
+  when: dspace_jmx_user is defined
         
 - name: Install JMX password file
   template:
     src: jmxremote.password.j2  
     dest: "{{ dspace_install_dir }}/etc/jmxremote.password"
-  when: jmx_user is defined
-# Do we also need a JMX Keystore?
+  when: dspace_jmx_user is defined
 
 - name: Install tomcat crontab for dspace 
   template:

--- a/tasks/tomcat.yml
+++ b/tasks/tomcat.yml
@@ -78,6 +78,7 @@
   template:
     src: jmxremote.password.j2  
     dest: "{{ dspace_install_dir }}/etc/jmxremote.password"
+    mode: 0600
   when: dspace_jmx_user is defined
 
 - name: Install tomcat crontab for dspace 

--- a/tasks/tomcat.yml
+++ b/tasks/tomcat.yml
@@ -55,3 +55,36 @@
   template:
     src: "tomcat.conf.j2"
     dest: "/etc/tomcat/tomcat.conf"
+
+
+# These can end up with a value that won't work for the tomcat service because
+# we build DSpace as tomcat.  
+- name: Set SELinux tomcat hsperfdata
+  command: >
+          semanage fcontext -a -t tomcat_tmp_t  "/tmp/hsperfdata_tomcat(/.*)?"
+
+- name: Set SELinux booleans
+  seboolean:
+    name: tomcat_can_network_connect_db
+    state: yes
+
+- name: Install JMX user file
+  template:
+    src: jmxremote.access.j2  
+    dest: "{{ dspace_install_dir }}/etc/jmxremote.access"
+  when: jmx_user is defined
+        
+- name: Install JMX password file
+  template:
+    src: jmxremote.password.j2  
+    dest: "{{ dspace_install_dir }}/etc/jmxremote.password"
+  when: jmx_user is defined
+# Do we also need a JMX Keystore?
+
+- name: Install tomcat crontab for dspace 
+  template:
+    dest: /var/spool/cron/tomcat
+    src: tomcat-cron.j2
+    mode: 0600
+    owner: tomcat
+    group: tomcat

--- a/tasks/tomcat.yml
+++ b/tasks/tomcat.yml
@@ -50,3 +50,8 @@
       {
         "registry": "https://registry.bower.io"
       }
+
+- name: Update tomcat config
+  template:
+    src: "tomcat.conf.j2"
+    dest: "/etc/tomcat/tomcat.conf"

--- a/templates/jmxremote.access.j2
+++ b/templates/jmxremote.access.j2
@@ -1,0 +1,1 @@
+{{ jmx_user }} {{ jmx_access_type }}

--- a/templates/jmxremote.access.j2
+++ b/templates/jmxremote.access.j2
@@ -1,1 +1,1 @@
-{{ jmx_user }} {{ jmx_access_type }}
+{{ dspace_jmx_user }} {{ dspace_jmx_access_type }}

--- a/templates/jmxremote.password.j2
+++ b/templates/jmxremote.password.j2
@@ -1,1 +1,1 @@
-{{ jmx_user }} {{ jmx_password }}
+{{ dspace_jmx_user }} {{ dspace_jmx_password }}

--- a/templates/jmxremote.password.j2
+++ b/templates/jmxremote.password.j2
@@ -1,0 +1,1 @@
+{{ jmx_password }}

--- a/templates/jmxremote.password.j2
+++ b/templates/jmxremote.password.j2
@@ -1,1 +1,1 @@
-{{ jmx_password }}
+{{ jmx_user }} {{ jmx_password }}

--- a/templates/tomcat.conf.j2
+++ b/templates/tomcat.conf.j2
@@ -9,7 +9,7 @@ JAVA_HOME="{{ java_home | default('/usr/lib/jvm/jre') }}"
 CATALINA_HOME="{{ catalina_home | default('/usr/share/tomcat') }}"
 
 # System-wide tmp
-CATALINA_TMPDIR="{{ cataline_tmpdir | default('/var/cache/tomcat/temp') }}"
+CATALINA_TMPDIR="{{ catalina_tmpdir | default('/var/cache/tomcat/temp') }}"
 
 # You can pass some parameters to java here if you wish to
 #JAVA_OPTS="-Xminf0.1 -Xmaxf0.3"

--- a/templates/tomcat.conf.j2
+++ b/templates/tomcat.conf.j2
@@ -17,21 +17,21 @@ TOMCAT_CFG_LOADED="1"
 
 # In new-style instances, if CATALINA_BASE isn't specified, it will
 # be constructed by joining TOMCATS_BASE and NAME.
-TOMCATS_BASE="{{ tomcats_base }}"
+TOMCATS_BASE="{{ dspace_tomcats_base }}"
 
 # Where your java installation lives
-JAVA_HOME="{{ tomcat_java_home }}"
+JAVA_HOME="{{ dspace_tomcat_java_home }}"
 
 # Where your tomcat installation lives
-CATALINA_HOME="{{ tomcat_catalina_home }}"
+CATALINA_HOME="{{ dspace_tomcat_catalina_home }}"
 
 # System-wide tmp
-CATALINA_TMPDIR="{{ tomcat_catalina_tmpdir }}"
+CATALINA_TMPDIR="{{ dspace_tomcat_catalina_tmpdir }}"
 
 # You can pass some parameters to java here if you wish to
 #JAVA_OPTS="-Xminf0.1 -Xmaxf0.3"
 #JAVA_OPTS="-Xmx512m -XX:MaxPermSize=256m"
-CATALINA_OPTS="{{ tomcat_catalina_opts }}"
+CATALINA_OPTS="{{ dspace_tomcat_catalina_opts }}"
 
 # Use JAVA_OPTS to set java.library.path for libtcnative.so
 #JAVA_OPTS="-Djava.library.path=/usr/lib"
@@ -40,7 +40,7 @@ CATALINA_OPTS="{{ tomcat_catalina_opts }}"
 #LANG="en_US"
 
 # Run tomcat under the Java Security Manager
-SECURITY_MANAGER="{{ tomcat_security_manager }}"
+SECURITY_MANAGER="{{ dspace_tomcat_security_manager }}"
 
 # Time to wait in seconds, before killing process
 # TODO(stingray): does nothing, fix.

--- a/templates/tomcat.conf.j2
+++ b/templates/tomcat.conf.j2
@@ -1,3 +1,20 @@
+# System-wide configuration file for tomcat services
+# This will be loaded by systemd as an environment file,
+# so please keep the syntax. For shell expansion support
+# place your custom files as /etc/tomcat/conf.d/*.conf
+#
+# There are 2 "classes" of startup behavior in this package.
+# The old one, the default service named tomcat.service.
+# The new named instances are called tomcat@instance.service.
+#
+# Use this file to change default values for all services.
+# Change the service specific ones to affect only one service.
+# For tomcat.service it's /etc/sysconfig/tomcat, for
+# tomcat@instance it's /etc/sysconfig/tomcat@instance.
+
+# This variable is used to figure out if config is loaded or not.
+TOMCAT_CFG_LOADED="1"
+
 # In new-style instances, if CATALINA_BASE isn't specified, it will
 # be constructed by joining TOMCATS_BASE and NAME.
 TOMCATS_BASE="{{ tomcats_base | default('/var/lib/tomcats/') }}"

--- a/templates/tomcat.conf.j2
+++ b/templates/tomcat.conf.j2
@@ -14,7 +14,7 @@ CATALINA_TMPDIR="{{ cataline_tmpdir | default('/var/cache/tomcat/temp') }}"
 # You can pass some parameters to java here if you wish to
 #JAVA_OPTS="-Xminf0.1 -Xmaxf0.3"
 #JAVA_OPTS="-Xmx512m -XX:MaxPermSize=256m"
-CATALINA_OPTS="{{ catlina_opts | default('-Xmx512m -Xms512m') }}"
+CATALINA_OPTS="{{ catalina_opts | default('-Xmx512m -Xms512m') }}"
 
 # Use JAVA_OPTS to set java.library.path for libtcnative.so
 #JAVA_OPTS="-Djava.library.path=/usr/lib"

--- a/templates/tomcat.conf.j2
+++ b/templates/tomcat.conf.j2
@@ -1,0 +1,34 @@
+# In new-style instances, if CATALINA_BASE isn't specified, it will
+# be constructed by joining TOMCATS_BASE and NAME.
+TOMCATS_BASE="{{ tomcats_base | default('/var/lib/tomcats/') }}"
+
+# Where your java installation lives
+JAVA_HOME="{{ java_home | default('/usr/lib/jvm/jre') }}"
+
+# Where your tomcat installation lives
+CATALINA_HOME="{{ catalina_home | default('/usr/share/tomcat') }}"
+
+# System-wide tmp
+CATALINA_TMPDIR="{{ cataline_tmpdir | default('/var/cache/tomcat/temp') }}"
+
+# You can pass some parameters to java here if you wish to
+#JAVA_OPTS="-Xminf0.1 -Xmaxf0.3"
+#JAVA_OPTS="-Xmx512m -XX:MaxPermSize=256m"
+CATALINA_OPTS="{{ catlina_opts | default('-Xmx512m -Xms512m') }}"
+
+# Use JAVA_OPTS to set java.library.path for libtcnative.so
+#JAVA_OPTS="-Djava.library.path=/usr/lib"
+
+# You can change your tomcat locale here
+#LANG="en_US"
+
+# Run tomcat under the Java Security Manager
+SECURITY_MANAGER="{{ security_manager | default('false')"
+
+# Time to wait in seconds, before killing process
+# TODO(stingray): does nothing, fix.
+# SHUTDOWN_WAIT="30"
+
+# If you wish to further customize your tomcat environment,
+# put your own definitions here
+# (i.e. LD_LIBRARY_PATH for some jdbc drivers)

--- a/templates/tomcat.conf.j2
+++ b/templates/tomcat.conf.j2
@@ -17,21 +17,21 @@ TOMCAT_CFG_LOADED="1"
 
 # In new-style instances, if CATALINA_BASE isn't specified, it will
 # be constructed by joining TOMCATS_BASE and NAME.
-TOMCATS_BASE="{{ tomcats_base | default('/var/lib/tomcats/') }}"
+TOMCATS_BASE="{{ tomcats_base }}"
 
 # Where your java installation lives
-JAVA_HOME="{{ java_home | default('/usr/lib/jvm/jre') }}"
+JAVA_HOME="{{ tomcat_java_home }}"
 
 # Where your tomcat installation lives
-CATALINA_HOME="{{ catalina_home | default('/usr/share/tomcat') }}"
+CATALINA_HOME="{{ tomcat_catalina_home }}"
 
 # System-wide tmp
-CATALINA_TMPDIR="{{ catalina_tmpdir | default('/var/cache/tomcat/temp') }}"
+CATALINA_TMPDIR="{{ tomcat_catalina_tmpdir }}"
 
 # You can pass some parameters to java here if you wish to
 #JAVA_OPTS="-Xminf0.1 -Xmaxf0.3"
 #JAVA_OPTS="-Xmx512m -XX:MaxPermSize=256m"
-CATALINA_OPTS="{{ catalina_opts | default('-Xmx512m -Xms512m') }}"
+CATALINA_OPTS="{{ tomcat_catalina_opts }}"
 
 # Use JAVA_OPTS to set java.library.path for libtcnative.so
 #JAVA_OPTS="-Djava.library.path=/usr/lib"
@@ -40,7 +40,7 @@ CATALINA_OPTS="{{ catalina_opts | default('-Xmx512m -Xms512m') }}"
 #LANG="en_US"
 
 # Run tomcat under the Java Security Manager
-SECURITY_MANAGER="{{ security_manager | default('false') }}"
+SECURITY_MANAGER="{{ tomcat_security_manager }}"
 
 # Time to wait in seconds, before killing process
 # TODO(stingray): does nothing, fix.

--- a/templates/tomcat.conf.j2
+++ b/templates/tomcat.conf.j2
@@ -23,7 +23,7 @@ CATALINA_OPTS="{{ catalina_opts | default('-Xmx512m -Xms512m') }}"
 #LANG="en_US"
 
 # Run tomcat under the Java Security Manager
-SECURITY_MANAGER="{{ security_manager | default('false')"
+SECURITY_MANAGER="{{ security_manager | default('false') }}"
 
 # Time to wait in seconds, before killing process
 # TODO(stingray): does nothing, fix.


### PR DESCRIPTION
When needing to implement JMX Monitoring it became apparent that there was no template for tomcat.conf

I added a new template file for it with defaults originating from our production box, except for Xmx and Xms which I lowered to 512m respectively. 

Catalina_opts will now be configured on a per-host/per-group basis in Ansible. 