### PR TITLE
Install ghostscript as required by filter-media.

### DIFF
--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Install RPMs required by DSpace
+  yum:
+    name:
+      - ghostscript 
+      - ghostscript-fonts
+
+
 - name: Make DSpace install destination folders
   file: 
     path: "{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   tags: dspace_tomcat
   become: true
 
-# Install DSpace-related role assets
+# Install DSpace requirements and role assets
 - import_tasks: assets.yml
   tags: dspace_assets
   become: true


### PR DESCRIPTION
Install ghostscript as required by filter-media toolchain for thumbnail generation. 