### PR TITLE
Split build.sh to make running safer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This role will install Dspace6 on a Centos7 box.
 
 It provides the following scripts for managing your DSpace install:
 
-* `bin/build.sh` - runs a `maven` build and `ant` install
-* `bin/clean.sh` - runs a `maven` clean    
+* `bin/build.sh` - runs `maven` build 
+* `bin/install.sh` - runs `ant` install
+* `bin/clean.sh` - runs `maven` clean    
 * `bin/fix_perms.sh` - applies known-good permissions and selinux context
 * `bin/git_pull.sh` - updates dspace source with correct permissions
 

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -38,6 +38,8 @@
   loop:
     - src: build.sh.j2
       dest: build.sh
+    - src: install.sh.j2
+      dest: install.sh
     - src: clean.sh.j2
       dest: clean.sh
     - src: fix_perms.sh.j2

--- a/tasks/dspace_build.yml
+++ b/tasks/dspace_build.yml
@@ -1,6 +1,8 @@
 ---
 
-- name: Build and install DSpace
+- name: Build  DSpace
   shell: "{{dspace_install_dir}}/bin/build.sh"
+- name: Install DSpace
+  shell: "{{dspace_install_dir}}/bin/install.sh"
 - name: Fix  DSpace permissions 
   shell: "{{dspace_install_dir}}/bin/fix_perms.sh"

--- a/templates/build.sh.j2
+++ b/templates/build.sh.j2
@@ -5,13 +5,6 @@
 # Load per-host configuration
 . {{dspace_install_dir}}/etc/conf.sh
 
-# Maybe skip restart?
-SKIP_RESTART=0
-if [ "$1" == "--skip-restart" ] ; then
-    SKIP_RESTART=1
-fi
-
-
 # make sure tomcat can open files that it may overwrite
 sudo chown -R tomcat:tomcat "${DSPACE_RUN}" 
 
@@ -31,29 +24,4 @@ else
    exit $OUT
 fi
 
-#
-# Install DSpace
-#
-cd "${DSPACE_SRC}/dspace/target/dspace-installer"
-if [ -d "${DSPACE_RUN}" ];then
-  sudo -u tomcat  $ANT  -Doverwrite=true update clean_backups
-else
-  sudo -u tomcat  $ANT fresh_install
-fi
-OUT=$?
-if [ $OUT -eq 0 ];then
-   echo "ANT install successful."
-else
-   echo "ANT install failed."
-   exit $OUT
-fi
 
-# make sure SELinux context is right
-sudo restorecon -rv {{dspace_install_dir}}
-
-if [ $SKIP_RESTART -eq 1 ];then
-  echo "Skipping restart of tomcat"
-else
-  echo "Restarting tomcat"
-  sudo systemctl restart tomcat
-fi

--- a/templates/install.sh.j2
+++ b/templates/install.sh.j2
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# File managed by Ansible, do not hand edit.
+
+# Load per-host configuration
+. {{dspace_install_dir}}/etc/conf.sh
+
+# Maybe skip restart?
+SKIP_RESTART=0
+if [ "$1" == "--skip-restart" ] ; then
+    SKIP_RESTART=1
+fi
+
+#
+# Install DSpace
+#
+cd "${DSPACE_SRC}/dspace/target/dspace-installer"
+if [ -d "${DSPACE_RUN}" ];then
+  sudo -u tomcat  $ANT  -Doverwrite=true update clean_backups
+else
+  sudo -u tomcat  $ANT fresh_install
+fi
+OUT=$?
+if [ $OUT -eq 0 ];then
+   echo "ANT install successful."
+else
+   echo "ANT install failed."
+   exit $OUT
+fi
+
+# make sure SELinux context is right
+sudo restorecon -rv {{dspace_install_dir}}
+
+if [ $SKIP_RESTART -eq 1 ];then
+  echo "Skipping restart of tomcat"
+else
+  echo "Restarting tomcat"
+  sudo systemctl restart tomcat
+fi


### PR DESCRIPTION
Split `build.sh` into `build.sh` and `install.sh` so that we have a chance to stop and review build output before installing. 