### PR TITLE
add installation of setroubleshoot rpm to base dspace install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,11 @@
   tags: dspace_build
   become: true
 
+# Install SELinux troubleshooting tools
+- import_tasks: se_tools.yml
+  tags: se_tools
+  become: true
+
 # Optionally install DSpace Handle service
 - import_tasks: dspace_handle.yml
   when: dspace_handle_repo | default(false)

--- a/tasks/se_tools.yml
+++ b/tasks/se_tools.yml
@@ -1,0 +1,8 @@
+---
+# Install tools for DSpace configuration or maintenance
+
+- name: Install SELinux troubleshooting RPM
+  yum:
+    name:
+      - setroubleshoot-server
+


### PR DESCRIPTION
I created a new file because this task didn't seem to fit neatly into existing files. I then added a block to call this file from main.yml.